### PR TITLE
add num_classes at turing label_id to matrix with keras

### DIFF
--- a/data/cnews_loader.py
+++ b/data/cnews_loader.py
@@ -108,7 +108,10 @@ def process_file(filename, word_to_id, cat_to_id, max_length=600):
 
     # 使用keras提供的pad_sequences来将文本pad为固定长度
     x_pad = kr.preprocessing.sequence.pad_sequences(data_id, max_length)
-    y_pad = kr.utils.to_categorical(label_id)  # 将标签转换为one-hot表示
+    cats = set([])
+    for key in cat_to_id:
+        cats.add(cat_to_id[key])
+    y_pad = kr.utils.to_categorical(label_id,num_classes=len(cats))  # 将标签转换为one-hot表示
 
     return x_pad, y_pad
 


### PR DESCRIPTION
在用keras的utils.to_categorical将label_id转换为matrix的时候,可能会出现以下情况: 
比如, 预先定义的类别数是10, 但是validation data中只有8个类别,那么转换出的矩阵就是x*8的,与placeholder定义的x*10不相符,进而出错,请看一下